### PR TITLE
Fix struct reserved bitwidth spacing in c_template.

### DIFF
--- a/corsair/templates/c_header.j2
+++ b/corsair/templates/c_header.j2
@@ -62,8 +62,8 @@ typedef struct {
     {% for bf in reg %}
         {% if tmp.lsb != bf.lsb %}
     {{ data_t() }} :{{ bf.lsb }}; // reserved
-            {% set tmp.lsb = bf.lsb %}
         {% endif %}
+        {% set tmp.lsb = bf.lsb + bf.width %}
     {{ data_t() }} {{ bf.name.upper() }} : {{ bf.width }}; // {{ bf.description }}
     {% endfor %}
 } {{ module_prefix()|lower }}{{ reg.name.lower() }}_t;


### PR DESCRIPTION
Previously, reserved bits would be inserted incorrectly into the struct.