### PR TITLE
Add generator for CMSIS SVD

### DIFF
--- a/corsair/__main__.py
+++ b/corsair/__main__.py
@@ -82,6 +82,7 @@ def generate_templates(format):
     targets.update(corsair.generators.CHeader(path="sw/regs.h").make_target('c_header'))
     targets.update(corsair.generators.Markdown(path="doc/regs.md", image_dir="md_img").make_target('md_doc'))
     targets.update(corsair.generators.Asciidoc(path="doc/regs.adoc", image_dir="adoc_img").make_target('asciidoc_doc'))
+    targets.update(corsair.generators.CmsisSvd(path="sw/regs.svd").make_target('cmsis_svd'))
 
     # create templates
     if format == 'txt':

--- a/corsair/generators.py
+++ b/corsair/generators.py
@@ -606,3 +606,37 @@ class Python(Generator, Jinja2):
         j2_vars['config'] = config.globcfg
         # render
         self.render_to_file(j2_template, j2_vars, self.path)
+
+
+class CmsisSvd(Generator, Jinja2):
+    """ Create the CMSIS SVD file.
+
+    :param rmap: Register map object
+    :type rmap: :class:`corsair.RegisterMap`
+    :param path: Path to the output file
+    :type path: str
+    """
+
+    def __init__(self, rmap=None, path='regs.svd', peripheral_name='CSR',
+                 description='no description', part_version='1.0.0', **args):
+        super().__init__(rmap, **args)
+        self.path = path
+        self.other = {'peripheral_name': peripheral_name,
+                      'description': description,
+                      'part_version': part_version}
+
+    def generate(self):
+        # validate parameters
+        self.validate()
+        for key, item in self.other.items():
+            assert item and utils.is_str(item), f'[SVD] {key} must be a non-empty string.'
+        # prepare jinja2
+        j2_template = 'cmsis_svd.j2'
+        j2_vars = {}
+        j2_vars['corsair_ver'] = __version__
+        j2_vars['rmap'] = self.rmap
+        j2_vars['config'] = config.globcfg
+        j2_vars['part_name'] = utils.get_file_name(self.path)
+        j2_vars.update(self.other)
+        # render
+        self.render_to_file(j2_template, j2_vars, self.path)

--- a/corsair/templates/cmsis_svd.j2
+++ b/corsair/templates/cmsis_svd.j2
@@ -1,0 +1,78 @@
+{#- value in hex format #}
+{% macro literal(reset, width) %}
+{{ "0x%0{w}x".format(w=width // 4) % reset }}
+{%- endmacro %}
+{#- sw access #}
+{% macro access(bf) %}
+{% if bf.access.startswith('ro') %}
+read-only
+{%- elif bf.access.startswith('wo') %}
+write-only
+{%- else %}
+read-write
+{%- endif %}
+{%- endmacro %}
+<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="https://raw.githubusercontent.com/ARM-software/CMSIS_5/develop/CMSIS/Utilities/CMSIS-SVD.xsd" >
+  <name>{{ part_name }}</name>
+  <version>{{ part_version }}</version>
+  <description>{{ description }}</description>
+  <addressUnitBits>{{ config.address_width }}</addressUnitBits>
+  <width>{{ config.data_width }}</width>
+  <size>{{ config.data_width }}</size>
+
+  <peripherals>
+    {% set min_offset = (rmap | map(attribute='address') | sort)[0] %}
+    {% set max_offset = (rmap | map(attribute='address') | sort)[-1] %}
+    <!-- {{ peripheral_name }} -->
+    <peripheral>
+      <name>{{ peripheral_name }}</name>
+      <baseAddress>{{ literal(config.base_address, config.address_width) }}</baseAddress>
+      <addressBlock>
+        <offset>{{ literal(min_offset, config.address_width) }}</offset>
+        <size>{{ '0x%x' % (max_offset - min_offset + config.data_width / config.address_width) | int }}</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+{% for reg in rmap %}
+        <!-- {{ reg.name }} -->
+        <register>
+          <name>{{ reg.name }}</name>
+{% if reg.description %}
+          <description>{{ reg.description }}</description>
+{% endif %}
+          <addressOffset>{{ literal(reg.address, config.address_width) }}</addressOffset>
+          <resetValue>{{ literal(reg.reset, config.data_width) }}</resetValue>
+
+          <fields>
+{% for bf in reg.bitfields %}
+            <!-- {{ bf.name }} -->
+            <field>
+              <name>{{ bf.name }}</name>
+{% if bf.description %}
+              <description>{{ bf.description }}</description>
+{% endif %}
+              <bitRange>[{{ bf.msb }}:{{ bf.lsb }}]</bitRange>
+              <access>{{ access(bf) }}</access>
+{% if bf.enums %}
+              <enumeratedValues>
+{% for enum in bf.enums %}
+                <enumeratedValue>
+                  <name>{{ enum.name }}</name>
+{% if enum.description %}
+                  <description>{{ enum.description }}</description>
+{% endif %}
+                  <value>{{ enum.value }}</value>
+                </enumeratedValue>
+{% endfor %}
+              </enumeratedValues>
+{% endif %}
+            </field>
+{% endfor %}
+          </fields>
+        </register>
+{% endfor %}
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>


### PR DESCRIPTION
This PR adds a generator for `CMSIS System View Description` files (see [here](https://www.keil.com/pack/doc/cmsis/SVD/html/index.html).

As described in #12, in a strictly correct SVD file, the registers are separated into peripherals. However, since this information is not provided in the current register definition, I've simply put them all into one peripheral for now (the name of which is defined as `peripheral_name` in the config file).
Additionally the `part_version` and a `description` also have to be given in the config file.

I've checked the output using CMSIS's [SVDConv tool](https://github.com/ARM-software/CMSIS_5/tree/develop/CMSIS/Utilities/Linux64).