### PR TITLE
fix: Reading external register with 0 latency

### DIFF
--- a/corsair/templates/apb2lb_verilog.j2
+++ b/corsair/templates/apb2lb_verilog.j2
@@ -54,7 +54,7 @@ assign wstrb = pstrb;
 assign wen   = psel & penable & pwrite;
 
 assign raddr = paddr;
-assign ren   = psel & (~pwrite);
+assign ren   = psel & penable & (~pwrite);
 {% endmacro %}
 {{ apb_core() }}
 endmodule

--- a/corsair/templates/apb2lb_vhdl.j2
+++ b/corsair/templates/apb2lb_vhdl.j2
@@ -71,7 +71,7 @@ wstrb <= pstrb;
 wen   <= psel and penable and pwrite;
 
 raddr <= paddr;
-ren   <= psel and (not pwrite);
+ren   <= psel and penable and (not pwrite);
 {% endmacro %}
 {{ apb_core() }}
 end arch_imp;

--- a/corsair/templates/regmap_verilog.j2
+++ b/corsair/templates/regmap_verilog.j2
@@ -441,10 +441,10 @@ end
             {% if tmp.fifo_cnt == 0 %}
 reg rvalid_drv;
 always @(*) begin
-    if ({{ sig_csr_ren(reg) }})
+    if ({{ sig_csr_ren_ff(reg) }})
         rvalid_drv = {{ sig_bf_rvalid_ff(reg, bf) }};
             {% else %}
-    else if ({{ sig_csr_ren(reg) }})
+    else if ({{ sig_csr_ren_ff(reg) }})
         rvalid_drv = {{ sig_bf_rvalid_ff(reg, bf) }};
             {% endif %}
             {% set tmp.fifo_cnt = tmp.fifo_cnt + 1 %}

--- a/corsair/templates/regmap_vhdl.j2
+++ b/corsair/templates/regmap_vhdl.j2
@@ -542,7 +542,7 @@ rdata <= rdata_ff;
 rvalid_drv <=
                  {% set tmp.fifo_cnt = tmp.fifo_cnt + 1 %}
             {% endif %}
-    {{ sig_bf_rvalid_ff(reg, bf) }} when ({{ sig_csr_ren(reg) }} = '1') else
+    {{ sig_bf_rvalid_ff(reg, bf) }} when ({{ sig_csr_ren_ff(reg) }} = '1') else
         {% endif %}
     {% endfor %}
 {% endfor %}

--- a/tests/hdl/test_lb_bridge/tb.sv
+++ b/tests/hdl/test_lb_bridge/tb.sv
@@ -124,6 +124,15 @@ initial begin : main
     if (data != 'hc0debabe)
         errors++;
 
+    // test read with 0 latency
+    addr = 'h014;
+    fork
+        mst.read(addr, data);
+        handle_read(addr, 0);
+    join
+    if (data != 'hc0debabe)
+        errors++;
+
     // test read with wait states
     addr = 'h008;
     fork

--- a/tests/hdl/test_rmap/tb_ro.sv
+++ b/tests/hdl/test_rmap/tb_ro.sv
@@ -108,22 +108,26 @@ task test_ro_iq;
     $display("%0t, Start RO+IQ tests!", $time);
     // push 5 elements to the fifo
     fifo.delete();
-    for (int i=0; i<5; i++) begin
+    for (int i=1; i<6; i++) begin
         fifo.push_front((i + 4096) * i);
     end
     addr = CSR_REGROQ_ADDR;
     // read 5 elements from the fifo with data values control
     fork
-        for (int i=0; i<5; i++) begin
+        for (int i=1; i<6; i++) begin
             mst.read(addr, data);
             if (data !== ((i + 4096) * i))
                 errors++;
         end
+        csr_regroq_bfiq_rvalid <= 1'b1;
+        csr_regroq_bfiq_in <= fifo.pop_back();
         for (int i=0; i<5; i++) begin
             wait (csr_regroq_bfiq_ren);
             repeat (i+1) @(posedge clk);
-            csr_regroq_bfiq_in <= fifo.pop_back();
-            csr_regroq_bfiq_rvalid <= 1'b1;
+            if (i != 0) begin
+                csr_regroq_bfiq_in <= fifo.pop_back();
+                csr_regroq_bfiq_rvalid <= 1'b1;
+            end
             @(posedge clk);
             csr_regroq_bfiq_rvalid <= 1'b0;
             @(posedge clk);


### PR DESCRIPTION
Problems:
* In case of 0 latency response of the external registers user have incorrect data with AXILite and Avalon bus
* In case of APB bus and 0 latency bridge local bus <> APB was broken

What's new:
* Added tests with 0 latency to the bridges TB
* Added tests with 0 latency to regmap TB

What's fixed:
* APB bus in case of 0 latency read response
* regmap in case of 0 latency read response from external response (FWFT FIFO)

Note:
Added one additional clock delay to data reading just to implement the same code for zero and non-zero latency cases