### PR TITLE
Fixed an error that occurred in the HDL (Verilog/VHDL) templates when bit fields are defined such that it results in a 1 bit wide 'reserved' field at position MSB.

### DIFF
--- a/corsair/templates/regmap_verilog.j2
+++ b/corsair/templates/regmap_verilog.j2
@@ -253,7 +253,7 @@ assign {{ sig_csr_rdata(reg) }}{{ range(bf.lsb - 1, tmp.last_bit) }} = {{ zeros(
         {% endif %}
         {% set tmp.last_bit = bf.msb + 1 %}
     {% endfor %}
-    {% if config['data_width'] - 1 > tmp.last_bit %}
+    {% if config['data_width'] > tmp.last_bit %}
 assign {{ sig_csr_rdata(reg) }}{{ range(config['data_width'] - 1, tmp.last_bit) }} = {{ zeros(config['data_width'] - tmp.last_bit) }};
     {% endif %}
 

--- a/corsair/templates/regmap_vhdl.j2
+++ b/corsair/templates/regmap_vhdl.j2
@@ -362,7 +362,7 @@ begin
         {% endif %}
         {% set tmp.last_bit = bf.msb + 1 %}
     {% endfor %}
-    {% if config['data_width'] - 1 > tmp.last_bit %}
+    {% if config['data_width'] > tmp.last_bit %}
 {{ sig_csr_rdata(reg) }}{{ range(config['data_width'] - 1, tmp.last_bit) }} <= {{ zeros(config['data_width'] - tmp.last_bit) }};
     {% endif %}
 


### PR DESCRIPTION
Fixed an error that occurred in the HDL (Verilog/VHDL) templates when bit fields are defined such that it results in a 1 bit wide **'reserved'** field at position **MSB**.

Example:

- **regs.yaml**
```
regmap:
-   name: DATA
    description: Data register
    address: 4
    bitfields:
    -   name: PERR2
        description: Parity error flag. Read to clear.
        reset: 0
        width: 1
        lsb: 30
        access: rolh
        hardware: i
        enums: []
```

- regs.v
```//------------------------------------------------------------------------------
// CSR:
// [0x4] - DATA - Data register
//------------------------------------------------------------------------------
wire [31:0] csr_data_rdata;
assign csr_data_rdata[29:0] = 30'h0;
```
**FIXED:**
```
//------------------------------------------------------------------------------
// CSR:
// [0x4] - DATA - Data register
//------------------------------------------------------------------------------
wire [31:0] csr_data_rdata;
assign csr_data_rdata[29:0] = 30'h0;
assign csr_data_rdata[31] = 1'b0;
```
- regs.vhd

```
--------------------------------------------------------------------------------
-- CSR:
-- [0x4] - DATA - Data register
--------------------------------------------------------------------------------
csr_data_rdata(29 downto 0) <= (others => '0');
```
**FIXED:**
```
--------------------------------------------------------------------------------
-- CSR:
-- [0x4] - DATA - Data register
--------------------------------------------------------------------------------
csr_data_rdata(29 downto 0) <= (others => '0');
csr_data_rdata(31) <= '0';
```