### PR TITLE
Allow source only installations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "GitPython"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,12 @@ def git_version(version):
 
     repo.git.status()
     # assert versions are increasing
-    latest_tag = repo.git.describe(
-        match='v[0-9]*', tags=True, abbrev=0)
+    try:
+        latest_tag = repo.git.describe(
+            match='v[0-9]*', tags=True, abbrev=0)
+    except git.exc.GitCommandError:
+        # No tags found
+        latest_tag = version
     assert parse_version(latest_tag) <= parse_version(version), (
         latest_tag, version)
     sha = repo.head.commit.hexsha[:8]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,13 @@ VERSION = "1.0.4"
 def git_version(version):
     """Return version with local version identifier."""
     import git
-    repo = git.Repo('.git')
+
+    try:
+        repo = git.Repo('.git')
+    except git.NoSuchPathError:
+        # Not in a git repo, assume install through PyPI / source distribution
+        return version
+
     repo.git.status()
     # assert versions are increasing
     latest_tag = repo.git.describe(


### PR DESCRIPTION
Previously, `pip install corsair --no-binary :all:` would fail due to
`setup.py` critically relying on `.git` being present. This patch will
detect a missing `.git` and assume a PyPI/source installation.