### PR TITLE
Register waccess

### DIFF
--- a/corsair/templates/regmap_verilog.j2
+++ b/corsair/templates/regmap_verilog.j2
@@ -380,10 +380,12 @@ assign {{ port_bf_wen(reg, bf) }} = {{ sig_csr_wen(reg) }};
     end
 end
 
+        {% if 'w' in bf.access %}
 {{ always_begin(sig=port_bf_waccess_ff(reg, bf), width=1, init=0) }} begin
         {{ port_bf_waccess_ff(reg, bf) }} <= wready && {{ sig_csr_wen(reg) }};
     end
 end
+        {% endif %}
 
         {% if 'r' in bf.access and 'q' in bf.hardware %}
 reg {{ sig_bf_rvalid_ff(reg, bf) }};

--- a/corsair/templates/regmap_verilog.j2
+++ b/corsair/templates/regmap_verilog.j2
@@ -141,6 +141,11 @@ csr_{{ reg.name.lower() }}_{{ bf.name.lower() }}_raccess
 csr_{{ reg.name.lower() }}_{{ bf.name.lower() }}_waccess
 {%- endmacro %}
 
+{#- port: bitfield write access strobe registered #}
+{% macro port_bf_waccess_ff(reg, bf) %}
+csr_{{ reg.name.lower() }}_{{ bf.name.lower() }}_waccess_ff
+{%- endmacro %}
+
 {#- port: bitfield lock signal #}
 {% macro port_bf_lock(reg, bf) %}
 csr_{{ reg.name.lower() }}_{{ bf.name.lower() }}_lock
@@ -280,13 +285,15 @@ end
 //---------------------
         {% if 'a' in bf.hardware %}
             {% if 'o' in bf.hardware %}
-assign {{ port_bf_waccess(reg, bf) }} = wready && {{ sig_csr_wen(reg) }};
+{# assign {{ port_bf_waccess(reg, bf) }} = wready && {{ sig_csr_wen(reg) }}; #}
+assign {{ port_bf_waccess(reg, bf) }} = {{ port_bf_waccess_ff(reg, bf) }};
             {% endif %}
             {% if 'i' in bf.hardware %}
 assign {{ port_bf_raccess(reg, bf) }} = rvalid && {{ sig_csr_ren(reg) }};
             {% endif %}
         {% endif %}
 reg {{ range_decl(bf.width - 1, bf.is_vector()) }} {{ sig_bf_ff(reg, bf) }};
+reg {{ port_bf_waccess_ff(reg, bf) }};
 
         {% if 'wo' in bf.access %}
 assign {{ sig_csr_rdata(reg) }}{{ range(bf.msb, bf.lsb) }} = {{ zeros(bf.width) }};
@@ -307,7 +314,6 @@ assign {{ port_bf_ren(reg, bf) }} = {{ sig_csr_ren(reg) }} & (~{{ sig_csr_ren_ff
         {% if 'w' in bf.access and 'q' in bf.hardware %}
 assign {{ port_bf_wen(reg, bf) }} = {{ sig_csr_wen(reg) }};
         {% endif %}
-
 {{ always_begin(sig=sig_bf_ff(reg, bf), width=bf.width, init=bf.reset)
 }} {% if 'l' in bf.hardware %}if (!{{ port_bf_lock(reg, bf) }}){% endif %} begin
         {% if 's' in bf.hardware %}
@@ -371,6 +377,11 @@ assign {{ port_bf_wen(reg, bf) }} = {{ sig_csr_wen(reg) }};
             {{ sig_bf_ff(reg, bf) }} <= {{ sig_bf_ff(reg, bf) }};
         {% endif %}
         end
+    end
+end
+
+{{ always_begin(sig=port_bf_waccess_ff(reg, bf), width=1, init=0) }} begin
+        {{ port_bf_waccess_ff(reg, bf) }} <= wready && {{ sig_csr_wen(reg) }};
     end
 end
 

--- a/corsair/templates/regmap_vhdl.j2
+++ b/corsair/templates/regmap_vhdl.j2
@@ -172,6 +172,11 @@ csr_{{ reg.name.lower() }}_{{ bf.name.lower() }}_raccess
 csr_{{ reg.name.lower() }}_{{ bf.name.lower() }}_waccess
 {%- endmacro %}
 
+{#- port: bitfield write access strobe #}
+{% macro port_bf_waccess_ff(reg, bf) %}
+csr_{{ reg.name.lower() }}_{{ bf.name.lower() }}_waccess_ff
+{%- endmacro %}
+
 {#- port: bitfield lock signal #}
 {% macro port_bf_lock(reg, bf) %}
 csr_{{ reg.name.lower() }}_{{ bf.name.lower() }}_lock
@@ -384,7 +389,8 @@ begin
 -----------------------
         {% if 'a' in bf.hardware %}
             {% if 'o' in bf.hardware %}
-{{ port_bf_waccess(reg, bf) }} <= wready and {{ sig_csr_wen(reg) }};
+{# {{ port_bf_waccess(reg, bf) }} <= wready and {{ sig_csr_wen(reg) }}; #}
+{{ port_bf_waccess(reg, bf) }} <= {{ port_bf_waccess_ff(reg, bf) }};
             {% endif %}
             {% if 'i' in bf.hardware %}
 {{ port_bf_raccess(reg, bf) }} <= rvalid and {{ sig_csr_ren(reg) }};
@@ -491,6 +497,10 @@ begin
     {% if 'l' in bf.hardware %}
     end if;
     {% endif %}
+{{ process_end() }}
+
+{{ process_begin(sig=port_bf_waccess_ff(reg, bf), width=1, init=0)}}
+    {{ port_bf_waccess_ff(reg, bf)  }} <= wready and {{ sig_csr_wen(reg) }};
 {{ process_end() }}
 
         {% if 'r' in bf.access and 'q' in bf.hardware %}

--- a/corsair/templates/regmap_vhdl.j2
+++ b/corsair/templates/regmap_vhdl.j2
@@ -499,9 +499,11 @@ begin
     {% endif %}
 {{ process_end() }}
 
+        {% if 'w' in bf.access %}
 {{ process_begin(sig=port_bf_waccess_ff(reg, bf), width=1, init=0)}}
     {{ port_bf_waccess_ff(reg, bf)  }} <= wready and {{ sig_csr_wen(reg) }};
 {{ process_end() }}
+        {%endif%}
 
         {% if 'r' in bf.access and 'q' in bf.hardware %}
 {{ process_begin(sig=sig_bf_rvalid_ff(reg, bf)) }}

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 from pkg_resources import parse_version
 
-VERSION = "1.0.4"
+VERSION = "1.0.4+waccess"
 
 
 # Based on https://github.com/tulip-control/dd/blob/885a716a56e82bfee54b0178d0ce38298b85eb6a/setup.py#L68


### PR DESCRIPTION
Register waccess output to align with wdata.  This delays assertion of waccess by one cycle which aligns strobe with valid wdata.  Useful for directly writing to FIFO.  See issue #59 

- not simulated (don't have ModelSim handy)
- Verilog tested on hardware
- VHDL untested