### PR TITLE
Bugfix Verilog header template

### DIFF
--- a/corsair/templates/verilog_header.j2
+++ b/corsair/templates/verilog_header.j2
@@ -29,7 +29,7 @@
 // {{ reg.name }}.{{ bf.name }} - {{ bf.description }}
 `define {{ module_prefix()|upper }}{{ reg.name.upper() }}_{{ bf.name.upper() }}_WIDTH {{ bf.width }}
 `define {{ module_prefix()|upper }}{{ reg.name.upper() }}_{{ bf.name.upper() }}_LSB {{ bf.lsb }}
-`define {{ module_prefix()|upper }}{{ reg.name.upper() }}_{{ bf.name.upper() }}_MASK {{ "%d'h%x" % (config['data_width'], reg.address) }}
+`define {{ module_prefix()|upper }}{{ reg.name.upper() }}_{{ bf.name.upper() }}_MASK {{ "%d'h%x" % (config['data_width'], bf.mask) }}
 `define {{ module_prefix()|upper }}{{ reg.name.upper() }}_{{ bf.name.upper() }}_RESET {{ "%d'h%x" % (bf.width, bf.reset) }}
         {% for enum in bf %}
 `define {{ module_prefix()|upper }}{{ reg.name.upper() }}_{{ bf.name.upper() }}_{{ enum.name.upper() }} {{ "%d'h%x" % (bf.width, enum.value) }} //{{ enum.description }}


### PR DESCRIPTION
The Verilog header generation was using the register address instead of the bitfield mask, meaning that the *_MASK constants were not usable.

Looks like this is the same bug as existed in the C header file generation a while ago (https://github.com/esynr3z/corsair/commit/907ad40a43ded049bd55e5a14e2adbefc2ec4005).